### PR TITLE
Move Google Tag to Environment Variable and Update Author Description

### DIFF
--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -11,4 +11,5 @@ module.exports = {
     email: "me@andrewford.co.nz",
     url: process.env.SITE_URL + "/about/",
   },
+  gTag: process.env.GTAG,
 };

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -5,7 +5,7 @@ module.exports = {
   fullUrl: process.env.SITE_URL,
   language: "en",
   description:
-    "Andrew Ford is the host of Code with Andrew Ford, a YouTube channel dedicated to teaching you how to code. He is also a full-stack web developer, technical analyst and an educator.",
+    "Andrew Ford is the host of Code with Andrew Ford, a YouTube channel dedicated to teaching you how to code. He is also a full-stack web developer, mentor and an educator.",
   author: {
     name: "Andrew Ford",
     email: "me@andrewford.co.nz",

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -31,7 +31,7 @@
 		<link rel="canonical" href="https://andrewford.co.nz/{{ page.url }}">
 
 		<link rel="dns-prefetch" href="https://www.googletagmanager.com/">
-		<link href="https://www.googletagmanager.com/gtag/js?id=G-K39D2FSQEF" rel="preload" as="script">
+		<link href="https://www.googletagmanager.com/gtag/js?id={{ metadata.gTag}}" rel="preload" as="script">
 
 		{# Atom and JSON feeds included by default #}
 		<link rel="alternate" href="{{ metadata.fullUrl }}/feed/feed.xml" type="application/atom+xml" title="{{ metadata.title }}">
@@ -211,7 +211,7 @@
 		</script>
 
 		{# Google tag (gtag.js) #}
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-K39D2FSQEF"></script>
+		<script async src="https://www.googletagmanager.com/gtag/js?id={{ metadata.gTag}}"></script>
 		<script>
 			window.dataLayer = window.dataLayer || [];
 			function gtag() {
@@ -219,7 +219,7 @@
 			}
 			gtag('js', new Date());
 
-			gtag('config', 'G-K39D2FSQEF');
+			gtag('config', '{{ metadata.gTag}}');
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
Refactor the Google Tag implementation to use an environment variable for better configurability and update the author description in the metadata for clarity.