### PR TITLE
fix: handle JSON-encoded ALLOWED_ORIGINS environment variable

### DIFF
--- a/api/server.mjs
+++ b/api/server.mjs
@@ -18,9 +18,20 @@ const PORT = process.env.PORT || 3000;
 
 const corsOptions = {
   origin: (origin, callback) => {
-    const allowedOrigins = process.env.ALLOWED_ORIGINS
-      ? process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim())
-      : ["http://localhost:3000", "https://andrewford.co.nz"];
+    let allowedOrigins = ["http://localhost:3000", "https://andrewford.co.nz"];
+
+    if (process.env.ALLOWED_ORIGINS) {
+      try {
+        // Try parsing as JSON first (in case it's JSON-encoded)
+        const parsed = JSON.parse(process.env.ALLOWED_ORIGINS);
+        allowedOrigins = Array.isArray(parsed) ? parsed : [parsed];
+      } catch {
+        // If JSON parsing fails, treat as comma-separated string
+        allowedOrigins = process.env.ALLOWED_ORIGINS.split(",").map((o) =>
+          o.trim()
+        );
+      }
+    }
 
     // Allow requests with no origin (e.g., mobile apps, Postman)
     // or from allowed origins


### PR DESCRIPTION
This pull request improves the flexibility and robustness of CORS origin configuration in the `api/server.mjs` file. The main change is updating how the allowed origins are parsed from the `ALLOWED_ORIGINS` environment variable, supporting both JSON arrays and comma-separated strings.

CORS configuration improvements:

* Updated the logic in the CORS `origin` option to first attempt parsing `process.env.ALLOWED_ORIGINS` as a JSON array, falling back to a comma-separated string if parsing fails, making origin configuration more flexible and robust.CORS was rejecting valid origins when ALLOWED_ORIGINS was set as JSON array ["https://andrewford.co.nz"] instead of comma-separated string. Updated parsing logic to handle both JSON and comma-separated formats gracefully.