### PR TITLE
[Fix] Restore live homepage stylesheet loading

### DIFF
--- a/_data/metadata.mjs
+++ b/_data/metadata.mjs
@@ -1,5 +1,11 @@
+import fs from "node:fs";
+import path from "node:path";
 import dotenv from "dotenv";
 dotenv.config();
+
+const stylesheetVersion = fs.statSync(
+  path.join(process.cwd(), "public/css/style.css")
+).mtimeMs;
 
 export default {
   title: "Andrew Ford",
@@ -14,5 +20,6 @@ export default {
     email: "me@andrewford.co.nz",
     url: `${process.env.SITE_URL || "https://andrewford.co.nz"}/about/`,
   },
+  stylesheetVersion,
   gTag: process.env.GTAG,
 };

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -94,8 +94,8 @@
 		</style>
 
 		{# Non-critical styles #}
-		<link rel="preload" href="/css/style.css" as="style">
-		<link rel="stylesheet" href="/css/style.css">
+		<link rel="preload" href="/css/style.css?v={{ metadata.stylesheetVersion }}" as="style">
+		<link rel="stylesheet" href="/css/style.css?v={{ metadata.stylesheetVersion }}">
 
 		{# Add the contents of a file to the JS bundle #}
 		{%- js %}{% include "public/scripts/lastFM.js" %}{% endjs %}

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -93,12 +93,9 @@
 			{% getBundle "css" %}
 		</style>
 
-		{%- css "styles" %}{% include "public/css/style.css" %}{% endcss %}
-
 		{# Non-critical styles #}
-		{% set stylesBundleUrl %}{% getBundleFileUrl 'css', 'styles' %}{% endset %}
-		<link rel="preload" href="{{ stylesBundleUrl }}" as="style">
-		<link rel="stylesheet" href="{{ stylesBundleUrl }}">
+		<link rel="preload" href="/css/style.css" as="style">
+		<link rel="stylesheet" href="/css/style.css">
 
 		{# Add the contents of a file to the JS bundle #}
 		{%- js %}{% include "public/scripts/lastFM.js" %}{% endjs %}

--- a/api/server.mjs
+++ b/api/server.mjs
@@ -54,7 +54,7 @@ const corsOptions = {
           const parsed = JSON.parse(cleaned);
           if (Array.isArray(parsed)) {
             return parsed.flatMap((item) =>
-              parseOriginsRecursively(String(item), depth + 1),
+              parseOriginsRecursively(String(item), depth + 1)
             );
           } else if (typeof parsed === "string") {
             return parseOriginsRecursively(parsed, depth + 1);
@@ -93,7 +93,7 @@ const corsOptions = {
             {
               original: process.env.ALLOWED_ORIGINS,
               parsed: allowedOrigins,
-            },
+            }
           );
           allowedOrigins = [
             "http://localhost:8080",
@@ -142,7 +142,7 @@ app.use(
       }
       return compression.filter(req, res);
     },
-  }),
+  })
 );
 app.use(express.json({ limit: "10mb" }));
 app.use(express.urlencoded({ extended: true }));
@@ -171,6 +171,10 @@ app.use((req, res, next) => {
   // Fonts - cache for 1 year
   else if (url.match(/\.(woff2?|ttf|eot|otf)$/i)) {
     res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+  }
+  // Stable stylesheet path needs revalidation because cache-busting is query-based
+  else if (url.startsWith("/css/style.css")) {
+    res.setHeader("Cache-Control", "public, max-age=3600, must-revalidate");
   }
   // JS/CSS - cache for 1 year (11ty uses hashed filenames)
   else if (url.match(/\.(js|css)$/i)) {
@@ -226,7 +230,7 @@ app.get("/health", async (_req, res) => {
 
     // Check for any critical issues
     const criticalIssues = Object.values(apiStatus).filter(
-      (status) => status === "missing",
+      (status) => status === "missing"
     ).length;
     if (criticalIssues > 0) {
       healthCheck.status = "degraded";
@@ -241,8 +245,8 @@ app.get("/health", async (_req, res) => {
     healthCheck.status === "healthy"
       ? 200
       : healthCheck.status === "degraded"
-        ? 200
-        : 503;
+      ? 200
+      : 503;
 
   res.status(statusCode).json(healthCheck);
 });


### PR DESCRIPTION
Fix the live homepage layout regression by loading the copied `/css/style.css` asset directly instead of the missing hashed bundle URL.

Testing Done
- npm run build
- npx playwright test tests/e2e/basic.spec.js --project=chromium
- pre-commit npx playwright test tests/e2e/chatbot-quick.spec.js --project=chromium