### PR TITLE
[Fix] Restore YouTube embed controls

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -220,6 +220,30 @@ picture {
   max-height: 720px;
   aspect-ratio: 16 / 9;
 }
+.video lite-youtube > .lty-playbtn {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: no-repeat center/68px 48px;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');
+  position: absolute;
+  cursor: pointer;
+  z-index: 1;
+  filter: grayscale(100%);
+  transition: filter 0.1s cubic-bezier(0, 0, 0.2, 1);
+  border: 0;
+}
+.video lite-youtube:hover > .lty-playbtn,
+.video lite-youtube .lty-playbtn:focus {
+  filter: none;
+}
+.video lite-youtube > div.lty-playbtn:not(.lyt-playbtn) {
+  pointer-events: none;
+}
+.video lite-youtube.lyt-activated > .lty-playbtn {
+  opacity: 0;
+  pointer-events: none;
+}
 .video > iframe {
   width: 100%;
   height: 100%;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,6 +4,13 @@
 - [x] Run the project verification suite.
 - [x] Commit, push, and open a PR to `main`.
 
+## Investigate YouTube embeds
+
+- [x] Reproduce the missing YouTube embeds on the live site.
+- [x] Trace how YouTube embeds are generated locally.
+- [x] Fix the root cause with the smallest safe change.
+- [x] Verify the fix locally and against representative pages.
+
 ## Review
 
 - Updated direct npm dependencies and refreshed the lockfile, including Eleventy, Playwright, LangChain, Express, DOMPurify, Prettier, Jest, Lighthouse, markdownlint, sanitize-html, supertest, and related packages.
@@ -12,3 +19,6 @@
 - Added `http-server` as an explicit dev dependency so the site-wide link test can start its local static server reliably.
 - Regenerated the lockfile with npm 10 so CI `npm ci` includes optional `@emnapi` package entries, and kept Lighthouse on `12.8.2` for Node 20 CI compatibility.
 - Verified with `npm audit`, `npm run build`, `npm run prettier:check`, and `npm run test:all`.
+- Found that live YouTube embeds rendered `<div class="lty-playbtn">` while `lite-youtube-embed@0.3.4` only styles `.lyt-playbtn`, making the play button invisible and unclickable.
+- Added a local CSS compatibility rule for the legacy `lty-playbtn` class so the lazy YouTube embeds have a visible, clickable play target again.
+- Verified the fix with a local browser click test, `npm audit`, `npm run build`, `npm run prettier:check`, and `npm run test:all`.


### PR DESCRIPTION
Summary: Restores visible, clickable controls for lazy YouTube embeds after the dependency update.\n\nTesting Done:\n- npm audit\n- npm run build\n- npm run prettier:check\n- npm run test:all\n- Browser click check on /articles/build-a-full-stack-next-js-set-up/ verified the youtube-nocookie iframe is created