### PR TITLE
[Fix] Restore latest video thumbnails

### DIFF
--- a/_data/latestVideos.mjs
+++ b/_data/latestVideos.mjs
@@ -7,6 +7,28 @@ config();
 
 const CACHE_DIR = "./public/images/youtube-cache";
 const PLACEHOLDER_PATH = "/images/video-placeholder.svg";
+const PLACEHOLDER_VALUES = [
+  "your_youtube_api_key_here",
+  "your_youtube_channel_id_here",
+  "your-youtube-key",
+  "your-channel-id",
+];
+
+function isMissingOrPlaceholder(value) {
+  if (!value) {
+    return true;
+  }
+
+  const normalizedValue = value.trim().toLowerCase();
+
+  return (
+    !normalizedValue ||
+    PLACEHOLDER_VALUES.includes(normalizedValue) ||
+    normalizedValue.includes("mock") ||
+    normalizedValue.includes("test") ||
+    normalizedValue.includes("placeholder")
+  );
+}
 
 async function ensureCacheDir() {
   try {
@@ -46,16 +68,11 @@ export default async () => {
     const apiKey = process.env.YOUTUBE_API_KEY;
     const channelId = process.env.YOUTUBE_CHANNEL_ID;
 
-    // Skip fetching if credentials are missing or are mock/test values
-    if (
-      !apiKey ||
-      !channelId ||
-      apiKey.includes("mock") ||
-      channelId.includes("mock") ||
-      apiKey.includes("test") ||
-      channelId.includes("test")
-    ) {
-      console.log("Skipping YouTube API fetch (credentials missing or mock)");
+    // Skip fetching if credentials are missing or placeholder values.
+    if (isMissingOrPlaceholder(apiKey) || isMissingOrPlaceholder(channelId)) {
+      console.log(
+        "Skipping YouTube API fetch (credentials missing or placeholder)",
+      );
       return { videos: [] };
     }
 
@@ -96,8 +113,10 @@ export default async () => {
     return {
       videos: videosWithCachedThumbs,
     };
-  } catch (e) {
-    console.error("Error in latestVideos.mjs: " + e);
+  } catch (error) {
+    console.warn(
+      "Skipping YouTube API fetch (configured credentials were rejected or the API is unavailable)",
+    );
     return {
       videos: [],
     };

--- a/api/server.mjs
+++ b/api/server.mjs
@@ -26,6 +26,30 @@ const notFoundPageContent = fs.existsSync(notFoundPage)
   ? fs.readFileSync(notFoundPage, "utf8")
   : defaultNotFoundPageContent;
 
+function setStaticCacheHeaders(res, filePath) {
+  const extension = path.extname(filePath).toLowerCase();
+  const normalizedFilePath = filePath.split(path.sep).join("/");
+
+  if (/\.(avif|webp|png|jpe?g|gif|svg|ico)$/i.test(extension)) {
+    res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+    return;
+  }
+
+  if (/\.(woff2?|ttf|eot|otf)$/i.test(extension)) {
+    res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+    return;
+  }
+
+  if (normalizedFilePath.endsWith("/css/style.css")) {
+    res.setHeader("Cache-Control", "public, max-age=3600, must-revalidate");
+    return;
+  }
+
+  if (/\.(js|css)$/i.test(extension)) {
+    res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+  }
+}
+
 const corsOptions = {
   origin: (origin, callback) => {
     let allowedOrigins = [
@@ -160,39 +184,24 @@ app.use((req, _res, next) => {
 // Handle redirects from _redirects file before static files
 app.use(createRedirectMiddleware());
 
-// Cache static assets with appropriate headers
+// Cache dynamic routes and let express.static cache only files that exist.
 app.use((req, res, next) => {
   const url = req.url;
 
-  // Images - cache for 1 year
-  if (url.match(/\.(avif|webp|png|jpe?g|gif|svg|ico)$/i)) {
-    res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
-  }
-  // Fonts - cache for 1 year
-  else if (url.match(/\.(woff2?|ttf|eot|otf)$/i)) {
-    res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
-  }
-  // Stable stylesheet path needs revalidation because cache-busting is query-based
-  else if (url.startsWith("/css/style.css")) {
+  if (url.match(/\.(html?)$/i) || url === "/" || !url.includes(".")) {
     res.setHeader("Cache-Control", "public, max-age=3600, must-revalidate");
-  }
-  // JS/CSS - cache for 1 year (11ty uses hashed filenames)
-  else if (url.match(/\.(js|css)$/i)) {
-    res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
-  }
-  // HTML - short cache with revalidation
-  else if (url.match(/\.(html?)$/i) || url === "/" || !url.includes(".")) {
-    res.setHeader("Cache-Control", "public, max-age=3600, must-revalidate");
-  }
-  // Default - moderate cache
-  else {
+  } else if (!path.extname(url)) {
     res.setHeader("Cache-Control", "public, max-age=86400");
   }
 
   next();
 });
 
-app.use(express.static(siteDirectory));
+app.use(
+  express.static(siteDirectory, {
+    setHeaders: setStaticCacheHeaders,
+  }),
+);
 
 app.use("/api/chatrag", chatragRouter);
 app.use("/api/lastplayed", lastplayedRouter);
@@ -253,6 +262,7 @@ app.get("/health", async (_req, res) => {
 
 app.use((req, res) => {
   if (path.extname(req.path)) {
+    res.setHeader("Cache-Control", "no-store");
     res.status(404).end();
     return;
   }

--- a/eleventy.config.images.mjs
+++ b/eleventy.config.images.mjs
@@ -214,7 +214,7 @@ export default (eleventyConfig) => {
           formats: ["avif", "webp", "jpeg"],
           outputDir: path.join(eleventyConfig.dir.output, "img"),
           filenameFormat: function (id, src, width, format) {
-            return `yt-${videoId}-${width}.${format}`;
+            return `yt-${videoId}-${id}-${width}.${format}`;
           },
         });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11,6 +11,12 @@
 - [x] Fix the root cause with the smallest safe change.
 - [x] Verify the fix locally and against representative pages.
 
+## Fix Local YouTube Dev Warning
+
+- [x] Reproduce the local YouTube data fetch issue from placeholder env values.
+- [x] Treat placeholder YouTube credentials as unconfigured.
+- [x] Verify `npm run dev` no longer logs the YouTube API 400 error.
+
 ## Review
 
 - Updated direct npm dependencies and refreshed the lockfile, including Eleventy, Playwright, LangChain, Express, DOMPurify, Prettier, Jest, Lighthouse, markdownlint, sanitize-html, supertest, and related packages.
@@ -22,3 +28,5 @@
 - Found that live YouTube embeds rendered `<div class="lty-playbtn">` while `lite-youtube-embed@0.3.4` only styles `.lyt-playbtn`, making the play button invisible and unclickable.
 - Added a local CSS compatibility rule for the legacy `lty-playbtn` class so the lazy YouTube embeds have a visible, clickable play target again.
 - Verified the fix with a local browser click test, `npm audit`, `npm run build`, `npm run prettier:check`, and `npm run test:all`.
+- Found that README placeholder YouTube values were treated as real credentials during local dev, causing a YouTube API 400 response.
+- Changed optional YouTube fetch failures to a concise skip message so local dev can continue without logging a stack-like API error.

--- a/tests/integration.test.mjs
+++ b/tests/integration.test.mjs
@@ -149,5 +149,13 @@ describe("API Integration Tests", () => {
     test("should return 404 for non-existent API endpoints - Negative Path", async () => {
       const response = await request(app).get("/api/nonexistent").expect(404);
     });
+
+    test("should not long-cache missing static image assets", async () => {
+      const response = await request(app)
+        .get("/img/missing-youtube-thumbnail.avif")
+        .expect(404);
+
+      expect(response.headers["cache-control"]).toBe("no-store");
+    });
   });
 });


### PR DESCRIPTION
Summary: Fix the Latest Videos fetch/render path so optional YouTube API issues do not break local dev, and generated production thumbnails do not stay broken behind cached 404s.

Testing Done:
- Placeholder credential data-loader check
- Invalid credential data-loader check
- npm run dev
- npm run build
- npm run prettier:check
- node --experimental-vm-modules ./node_modules/jest/bin/jest.js tests/integration.test.mjs
- npm run test:all
- npm run test:e2e:quick
- docker build -t andrewford-blog .
